### PR TITLE
!HOTFIX: Fixed an issue where an existing UNNotificationRequest was overwritten due to duplicate saving of bookmarks

### DIFF
--- a/KNUTICE.xcodeproj/project.pbxproj
+++ b/KNUTICE.xcodeproj/project.pbxproj
@@ -2137,7 +2137,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fx.KNUTICE;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -2176,7 +2176,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fx.KNUTICE;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -2216,7 +2216,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS -DDEV";
 				PRODUCT_BUNDLE_IDENTIFIER = com.fx.KNUTICE.developer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2258,7 +2258,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS -DDEV";
 				PRODUCT_BUNDLE_IDENTIFIER = com.fx.KNUTICE.developer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2291,7 +2291,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fx.KNUTICE.developer.NotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2322,7 +2322,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fx.KNUTICE.developer.NotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2397,7 +2397,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fx.KNUTICE.NotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2427,7 +2427,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fx.KNUTICE.NotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/KNUTICE/Services/BookmarkService.swift
+++ b/KNUTICE/Services/BookmarkService.swift
@@ -25,14 +25,14 @@ final class BookmarkServiceImpl: BookmarkService {
     }
     
     func save(bookmark: Bookmark) -> AnyPublisher<Void, any Error> {
-        return UNUserNotificationCenter.current().registerLocalNotification(for: bookmark)
+        return bookmarkRepository.save(bookmark: bookmark)
             .flatMap { [weak self] _ -> AnyPublisher<Void, any Error> in
                 guard let self else {
                     return Fail(error: NSError(domain: "SelfDeallocated", code: -1))
                         .eraseToAnyPublisher()
                 }
                 
-                return self.bookmarkRepository.save(bookmark: bookmark)
+                return UNUserNotificationCenter.current().registerLocalNotification(for: bookmark)
             }
             .eraseToAnyPublisher()
     }


### PR DESCRIPTION
- Fixed an issue where an existing UNNotificationRequest was overwritten due to duplicate saving of bookmarks in KNUTICE 1.4.1

as-is
- UNNotificationRequest is registered first, before checking for bookmark duplication.
```swift
func save(bookmark: Bookmark) -> AnyPublisher<Void, any Error> {
    return UNUserNotificationCenter.current().registerLocalNotification(for: bookmark)
        .flatMap { [weak self] _ -> AnyPublisher<Void, any Error> in
            guard let self else {
                return Fail(error: NSError(domain: "SelfDeallocated", code: -1))
                    .eraseToAnyPublisher()
            }
                
            return self.bookmarkRepository.save(bookmark: bookmark)
        }
        .eraseToAnyPublisher()
    }
```

to-be
- UNNotificationRequest is registered after checking for bookmark duplication.
```swift
func save(bookmark: Bookmark) -> AnyPublisher<Void, any Error> {
    return bookmarkRepository.save(bookmark: bookmark)
        .flatMap { [weak self] _ -> AnyPublisher<Void, any Error> in
            guard let self else {
                return Fail(error: NSError(domain: "SelfDeallocated", code: -1))
                    .eraseToAnyPublisher()
            }
                
            return UNUserNotificationCenter.current().registerLocalNotification(for: bookmark)
        }
        .eraseToAnyPublisher()
    }
```
